### PR TITLE
Avoid Windows linker errors with GHC 9.4.5+

### DIFF
--- a/src/Text/Builder/ANSI.hs
+++ b/src/Text/Builder/ANSI.hs
@@ -60,8 +60,8 @@ import Data.Semigroup ((<>))
 import Text.Builder (Builder)
 import qualified Text.Builder as Builder
 import Data.Word (Word8)
-import Foreign.C (CInt (CInt))
 import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Internals (c_isatty)
 
 -- $intro
 --
@@ -369,9 +369,6 @@ isatty :: Bool
 isatty =
   unsafePerformIO (c_isatty 1) == 1
 {-# NOINLINE isatty #-}
-
-foreign import ccall unsafe "isatty"
-  c_isatty :: CInt -> IO CInt
 
 -- Collapse surround/surround to a single surround before phase 1
 {-# RULES

--- a/src/Text/Lazy/Builder/ANSI.hs
+++ b/src/Text/Lazy/Builder/ANSI.hs
@@ -61,8 +61,8 @@ import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder
 import Data.Word (Word8)
-import Foreign.C (CInt (CInt))
 import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Internals (c_isatty)
 
 -- $intro
 --
@@ -370,9 +370,6 @@ isatty :: Bool
 isatty =
   unsafePerformIO (c_isatty 1) == 1
 {-# NOINLINE isatty #-}
-
-foreign import ccall unsafe "isatty"
-  c_isatty :: CInt -> IO CInt
 
 -- Collapse surround/surround to a single surround before phase 1
 {-# RULES


### PR DESCRIPTION
Previously, `text-ansi` declared a direct `foreign import` on the `isatty` function. This is subtly incorrect on Windows, which provides an `_isatty` function rather than `isatty`. (See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-isatty?view=msvc-170)

This happened to work on pre-9.4.5 versions of GHC due to them linking against the `msvcrt` C runtime (which still provided `isatty`), but GHC 9.4.5 and later link against `ucrt`, which does not provide `isatty` at all. This manifests in linker errors when using `text-ansi` in GHCi or Template Haskell on Windows, as seen in https://gitlab.haskell.org/ghc/ghc/-/issues/23378 and in this `hledger` build: https://github.com/simonmichael/hledger/actions/runs/4931242306/jobs/8815809083

The solution is to instead declare a foreign import on `_isatty`. The `c_isatty` function from `System.Posix.Internals` in `base` already does this, in fact, so I have removed the hand-written `c_isatty` functions in `text-ansi` in favor of the one in `System.Posix.Internals`. (Despite that module's name, `System.Posix.Internals` is cross-platform and does in fact work on Windows.)